### PR TITLE
optimize: include response body in APIError for better error handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -336,6 +336,7 @@ func (c *Client) handleErrorResp(resp *http.Response) error {
 
 	errRes.Error.HTTPStatus = resp.Status
 	errRes.Error.HTTPStatusCode = resp.StatusCode
+	errRes.Error.Body = body
 	return errRes.Error
 }
 

--- a/error.go
+++ b/error.go
@@ -16,6 +16,7 @@ type APIError struct {
 	HTTPStatus     string      `json:"-"`
 	HTTPStatusCode int         `json:"-"`
 	InnerError     *InnerError `json:"innererror,omitempty"`
+	Body           []byte      `json:"-"`
 }
 
 // InnerError Azure Content filtering. Only valid for Azure OpenAI Service.


### PR DESCRIPTION
Added a Body field to the APIError struct to store the response body from HTTP errors. This enhancement allows for more detailed error reporting when handling API responses.

## Motivation
Many providers (e.g., OpenRouter) customize their error messages rather than using only Code, Message. Therefore, preserving the original body is necessary.

An example:  
When using OpenRouter with OpenAI, an error occurs and returns a very brief but useless error message:  
`400 Bad Request, message: Provider returned error.`

[OpenRouter documentation](https://openrouter.ai/docs/api/reference/errors-and-debugging#provider-errors) shows errors like this:

```
type ErrorResponse = {
  error: {
    code: number;
    message: string;
+   metadata?: Record<string, unknown>;
  };
};
```


Adding a `metadata` field in this project is not a good choice.
The simpler approach is to expose the body so developers can retrieve the full underlying error via the original body.
