### PR TITLE
fix: correct JSON tag for ChatMessageFile.FileName

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -99,7 +99,7 @@ type ChatMessageVideoURL struct {
 
 type ChatMessageFile struct {
 	FileData string `json:"file_data,omitempty"`
-	FileName string `json:"file_name,omitempty"`
+	FileName string `json:"filename,omitempty"`
 }
 
 type ChatMessagePartType string


### PR DESCRIPTION
Change the JSON tag from "file_name" to "filename" to match the OpenAI API specification.
